### PR TITLE
Work on #14.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This module determines which content model to assign to child objects based on t
 
 ```
 jpeg => islandora:sp_basic_image
-jpe => islandora:sp_basic_image
+jpg => islandora:sp_basic_image
 jpeg => islandora:sp_basic_image
 gif => islandora:sp_basic_image
 png => islandora:sp_basic_image
@@ -163,6 +163,15 @@ mov => islandora:sp_videoCModel
 ogv => islandora:sp_videoCModel
 ```
 
+You can override these mappings by providing a comma-separated list of extension-to-cmodel mappings in the optional `--content_models` drush option, like this:
+
+`drush -v --user=admin islandora_compound_batch_preprocess --content_models=pdf::islandora:fooCModel --target=/path/to/input/directory --namespace=mynamespace --parent=mynamespace:collection`
+
+or
+
+`drush -v --user=admin islandora_compound_batch_preprocess --content_models=pdf::islandora:fooCModel,jpg::islandora:bar_cmodel --target=/path/to/input/directory --namespace=mynamespace --parent=mynamespace:collection`
+
+
 ## Troubleshooting/Issues
 
 Please open an issue in this Github repo's issue queue.
@@ -178,7 +187,6 @@ at the University of Toronto Scarborough Library
 
 * Add support for hierarchical compound objects (i.e., with children that have children)
 * Graphical user interface
-* A way to allow overriding the extenstion to content model mapping
 
 ## Development
 

--- a/includes/object.inc
+++ b/includes/object.inc
@@ -90,8 +90,24 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
       $this->addRelationshipsForChild($parent_pid, $sequence_number);
 
       $file_extension = pathinfo($this->compoundObjFilePath, PATHINFO_EXTENSION);
-      $content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
-      $this->models = $content_model;
+      if ($this->preprocessorParameters['content_models']) {
+        $maps = explode(',', $this->preprocessorParameters['content_models']);
+        foreach ($maps as $map) {
+          if ($content_model = $cb_utilities->getContentModelFromParam($file_extension, $map)) {
+            $this->models = $content_model;
+            // We've got our content model, let's not continue.
+            break;
+          }
+          else {
+            $content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
+            $this->models = $content_model;
+          }
+        }
+      }
+      else {
+        $content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
+        $this->models = $content_model;
+      }
     }
     else {
       $this->models = 'islandora:compoundCModel';

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -65,6 +65,27 @@ class Utilies {
   }
 
   /**
+   * Parses optional --content_models drush param.
+   *
+   * @param string $fileExt
+   *   The extension of the current child object's payload file.
+   * @param string $map
+   *   The extention::cmodelPID map.
+   *
+   * @return string/bool
+   *   The PID of the content model to assign to the current child,
+   *   FALSE if the mapping doesn't apply.
+   */
+  public function getContentModelFromParam($fileExt, $map) {
+    list($targetExt, $cmodel) = explode('::', $map);
+    if (strlen($targetExt)) {
+      if ($targetExt == $fileExt) {
+        return trim($cmodel);
+      }
+    }
+  }
+
+  /**
    * Applies an XSLT transform to an XML string.
    * Based off of
    * islandora_solution_pack_xml_apply_xslt in

--- a/islandora_compound_batch.drush.inc
+++ b/islandora_compound_batch.drush.inc
@@ -31,6 +31,10 @@ function islandora_compound_batch_drush_command() {
         'description' => 'The namespace for objects created by this command.  Defaults to namespace set in Fedora config.',
         'required' => FALSE,
       ),
+      'content_models' => array(
+        'description' => 'Defines the (single) content model to apply to child data files that have a specific extension. Use format "ext::cmodel_pid.',
+        'value' => 'optional',
+      ),
       'parent' => array(
         'description' => 'The collection to which the generated items should be added.  If "directory" and the directory containing the object description is a valid PID, it will be set as the parent. If this is specified and itself is a PID, all compound objects will be related to the given PID.',
         'required' => TRUE,
@@ -75,6 +79,7 @@ function drush_islandora_compound_batch_preprocess() {
     'namespace' => drush_get_option('namespace'),
     'target' => drush_get_option('target'),
     'parent' => drush_get_option('parent', 'islandora:compoundCollection'),
+    'content_models' => drush_get_option('content_models'),
     'icbp_verbose' => drush_get_option('icbp_verbose'),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOf'),


### PR DESCRIPTION
To test, unzip the attached input data. It should have a structure like:

```
├── compound1
│   ├── 01
│   │   ├── MODS.xml
│   │   └── OBJ.tif
│   ├── 02
│   │   ├── MODS.xml
│   │   └── OBJ.tif
│   ├── 03
│   │   ├── MODS.xml
│   │   └── OBJ.tif
│   ├── MODS.xml
│   └── structure.xml
└── compound2
    ├── 01
    │   ├── MODS.xml
    │   └── OBJ.tif
    ├── 02
    │   ├── MODS.xml
    │   └── OBJ.pdf
    ├── 03
    │   ├── MODS.xml
    │   └── OBJ.jpg
    ├── 04
    │   ├── MODS.xml
    │   └── OBJ.tif
    ├── MODS.xml
    └── structure.xml
```

Notice that compound2's second child is a PDF, and its third is a JPG.

Run the following, adjusting the value of `--namespace`, `--target`, and `--parent` to suit your local requirements:

```
drush -v --user=admin islandora_compound_batch_preprocess --target=/tmp/csv_compound_output --namespace=mynamespace --content_models=pdf::islandora:placeCModel,jpg::islandora:eventCModel --parent=islandora:compound_collection
```
Then run `drush -v --user=admin islandora_batch_ingest` as usual.

The result of specifying the contend models for child objects created from the PDF and JPG files is that in "second compound object," the second child should have a content model of "Islandora Place Content Model". The third child should have a content model of "Islandora Event Content Model."

[issue14test.zip](https://github.com/MarcusBarnes/islandora_compound_batch/files/593720/issue14test.zip)

