### PR TITLE
compatibility with drush 6- and 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ After you have prepared your content, the remaining steps are much like those re
 
 The batch preprocessor is called as a drush script (see `drush help islandora_compound_batch_preprocess` for additional parameters):
 
+Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
+
+Drush 7 and above:
+
+`drush -v --user=admin islandora_compound_batch_preprocess --scan_target=/path/to/input/directory --namespace=mynamespace --parent=mynamespace:collection`
+
+Drush 6 and below:
+
 `drush -v --user=admin islandora_compound_batch_preprocess --target=/path/to/input/directory --namespace=mynamespace --parent=mynamespace:collection`
 
 This will populate the queue (stored in the Drupal database) with base entries.
@@ -164,6 +172,8 @@ ogv => islandora:sp_videoCModel
 ```
 
 You can override these mappings by providing a comma-separated list of extension-to-cmodel mappings in the optional `--content_models` drush option, like this:
+
+Note:  `--target` applies to drush 6 and below, while `--scan_target` replaces this keyword in drush 7 and above.
 
 `drush -v --user=admin islandora_compound_batch_preprocess --content_models=pdf::islandora:fooCModel --target=/path/to/input/directory --namespace=mynamespace --parent=mynamespace:collection`
 

--- a/islandora_compound_batch.drush.inc
+++ b/islandora_compound_batch.drush.inc
@@ -16,17 +16,18 @@ function islandora_compound_batch_drush_command() {
     'description' => 'Preprocess compound objects into database entries.',
     /*'drupal dependencies' => array('islandora_batch', 'islandora_solution_pack_compound'),*/
     'drupal dependencies' => array('islandora_batch'),
+    'examples' => array(
+      format_string('drush -v icbp --user=admin --content_models=islandora:sp_large_image_cmodel --namespace=yul --parent=yul:F0433 --@target=/tmp/batch_ingest/ --icbp_verbose=TRUE',
+      array(
+        '@target' => DRUSH_VERSION >= 7 ? 'scan_target' : 'target',
+      )),
+    ),
     'options' => array(
       /*
       'type' => array(
         'description' => 'Either "directory" or "zip".',
         'required' => TRUE,
       ),*/
-      'target' => array(
-        /*'description' => 'The target to directory or zip file to scan.',*/
-        'description' => 'The target to directory to scan.',
-        'required' => TRUE,
-      ),
       'namespace' => array(
         'description' => 'The namespace for objects created by this command.  Defaults to namespace set in Fedora config.',
         'required' => FALSE,
@@ -51,10 +52,26 @@ function islandora_compound_batch_drush_command() {
         'description' => 'The predicate of the relationship to the parent. Defaults to "isMemberOf".',
         'value' => 'optional',
       ),
-
+//
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
+  // XXX: The target parameter became reserved in Drush 7 and above, for
+  // backwards compatibility both will be supported. Not using
+  // strict-option-handling (http://www.drush.org/en/master/strict-options) as
+  // it requires manual argument parsing.
+  if (DRUSH_VERSION >= 7) {
+    $items['islandora_compound_batch_preprocess']['options']['scan_target'] = array(
+      'description' => 'The target to directory or zip file to scan. Requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip',
+      'required' => TRUE,
+    );
+  }
+  else {
+    $items['islandora_compound_batch_preprocess']['options']['target'] = array(
+      'description' => 'The target to directory or zip file to scan. Requires the full path to your archive from root directory. e.g. /var/www/drupal/sites/archive.zip',
+      'required' => TRUE,
+    );
+  }
   $items['islandora_compound_batch_prune_relationships'] = array(
     'aliases' => array('icbpr'),
     'description' => 'Removes rows from the islandora_compound_batch table that no longer have a batch associated with them.',
@@ -77,7 +94,7 @@ function drush_islandora_compound_batch_preprocess() {
   $parameters = array(
     'type' => drush_get_option('type'),
     'namespace' => drush_get_option('namespace'),
-    'target' => drush_get_option('target'),
+    'target' => DRUSH_VERSION >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'parent' => drush_get_option('parent', 'islandora:compoundCollection'),
     'content_models' => drush_get_option('content_models'),
     'icbp_verbose' => drush_get_option('icbp_verbose'),


### PR DESCRIPTION
Drush 7 reserved the keyword "target", which breaks other libraries that used "--target" as a keyword (including this library).

Following in the pattern of islandora batch and islandora batch book ingest,
and in order to not break dependencies for users of drush 6 or less (who are successfully using "--target") --
This change requires users of drush 6 or less to continue their practice of using "--target", and it requires users of drush 7 or greater to use "--scan_target".

The "drush icbp --help" text matches drush version.

The function of the script is unchanged. Only this change: Drush version affects the required keyword, and changes the --help text and the example text.

![drush6_success](https://user-images.githubusercontent.com/6989085/28138440-62eaf7fe-6716-11e7-83e8-7353b71e41d9.png)
![drush6_success2](https://user-images.githubusercontent.com/6989085/28138442-645c52d6-6716-11e7-9e84-b551001b3475.png)
![drush9_success](https://user-images.githubusercontent.com/6989085/28138444-680ed480-6716-11e7-9740-6bcd202123c6.png)
