### PR TITLE
removes non-functional GUI button

### DIFF
--- a/islandora_compound_batch.module
+++ b/islandora_compound_batch.module
@@ -7,21 +7,21 @@
 /**
  * Implements hook_menu().
  */
-function islandora_compound_batch_menu() {
-  $items = array();
+// function islandora_compound_batch_menu() {
+//   $items = array();
 
-  $items['islandora/object/%islandora_object/manage/collection/compound_batch'] = array(
-    'title' => 'Compound Batch',
-    'access callback' => 'islandora_compound_batch_menu_access',
-    'access arguments' => array(2),
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_compound_batch_form', 2),
-    'file' => 'includes/batch.form.inc',
-    'type' => MENU_LOCAL_ACTION,
-  );
+//   $items['islandora/object/%islandora_object/manage/collection/compound_batch'] = array(
+//     'title' => 'Compound Batch',
+//     'access callback' => 'islandora_compound_batch_menu_access',
+//     'access arguments' => array(2),
+//     'page callback' => 'drupal_get_form',
+//     'page arguments' => array('islandora_compound_batch_form', 2),
+//     'file' => 'includes/batch.form.inc',
+//     'type' => MENU_LOCAL_ACTION,
+//   );
 
-  return $items;
-}
+//   return $items;
+// }
 
 /**
  * Menu access callback.


### PR DESCRIPTION
To avoid confusion to the end-user, the function "islandora_compound_batch_menu()" is commented out.  The drush commands still work.  Only the end-user no longer sees the non-working "Compound Batch" button.

I hope to finish the code, to make the GUI interface work.  Our end users are eager to see us provide this feature.  But in the meantime, this version simply hides the GUI.  

I have no strong opinion whether you should accept this pull request or not.  Hopefully, I'll have another pull request soon that finishes what you all have already put together. 