### PR TITLE
Allow assignment of content model for parent objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ input_directory
 ```
 The names of the parent and child directories don't matter, but the names of the files within them do, as explained below.
 
-This module will ingest objects that do not have the content model 'islandora:compoundCmodel' if a file named `OBJ` is in the parent's directory. The content model assigned to the parent object is determined by the extension of the OBJ file. For example, if `OBJ.pdf` is present in the `parent_one` directory, that object will be assigned the 'islandora:sp_pdf' content model and will have the `OBJ.pdf` file as its OBJ datastream, and the same object will also have `first_child` and `second_child` as children:
+This module will ingest objects that do not have the 'islandora:compoundCmodel' content model if a file named `OBJ` is in the parent's directory. The content model assigned to the parent object is determined by the extension of the OBJ file. For example, if `OBJ.pdf` is present in the `parent_one` directory, that object will be assigned the 'islandora:sp_pdf' content model and will have the `OBJ.pdf` file as its OBJ datastream, and will also have `first_child` and `second_child` as children:
 
 ```
 input_directory

--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ input_directory
 ```
 The names of the parent and child directories don't matter, but the names of the files within them do, as explained below.
 
+This module will ingest objects that do not have the content model 'islandora:compoundCmodel' if a file named `OBJ` is in the parent's directory. The content model assigned to the parent object is determined by the extension of the OBJ file. For example, if `OBJ.pdf` is present in the `parent_one` directory, that object will be assigned the 'islandora:sp_pdf' content model and will have the `OBJ.pdf` file as its OBJ datastream, and the same object will also have `first_child` and `second_child` as children:
+
+```
+input_directory
+├── parent_one
+│   ├── first_child
+│   │   ├── MODS.xml
+│   │   └── OBJ.jp2
+│   ├── second_child
+│   │   ├── MODS.xml
+│   │   └── OBJ.jp2
+│   └── OBJ.pdf 
+│   └── MODS.xml
+└── parent_two
+    ├── first_child
+    │   ├── MODS.xml
+    │   └── OBJ.jp2
+    ├── second_child
+    │   ├── MODS.xml
+    │   └── OBJ.jp2
+    └── MODS.xml
+```
+
 #### Step 2: Generating structure files
 
 Once you have your content arranged, you will need to generate a 'structure file' for each object. To do this, run the `create_structure_files.php` script in this module's extras/scripts directory: `php create_strcutre_files.php path/to/directory/containing/compound_objects`. Running this script will add a `structure.xml` file to each parent object:

--- a/includes/object.inc
+++ b/includes/object.inc
@@ -32,17 +32,8 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     $pathinfo = pathinfo($this->compoundObjFilePath);
     $dir_name = $pathinfo['dirname'];
     $file_name = $pathinfo['filename'];
-    if ($file_name != 'MODS' || $file_name != 'OBJ') {
-      $this->loadObjDatastream($this->compoundObjFilePath);
-/*
-      $obj = $this->constructDatastream('OBJ', 'M');
-      $obj->label = 'OBJ Datastream';
-      // Must infer mimetype from file.
-      $mime_detector = new MimeDetect();
-      $obj->mimetype = $mime_detector->getMimetype($this->compoundObjFilePath);
-      $obj->setContentFromFile($this->compoundObjFilePath, FALSE);
-      $this->ingestDatastream($obj);
-*/
+    if ($file_name == 'OBJ') {
+      $this->loadObjDatastream();
     }
 
     module_load_include('inc', 'islandora_compound_batch', 'includes/utilities');
@@ -115,7 +106,6 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     else {
       $parent_obj_pattern = $dir_name . DIRECTORY_SEPARATOR . 'OBJ.*';
       $obj_file_list = glob($parent_obj_pattern);
-      dd($obj_file_list, 'OBJ file list');
       if (count($obj_file_list) === 1) {
         $file_extension = pathinfo($obj_file_list[0], PATHINFO_EXTENSION);
         $parent_content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
@@ -186,7 +176,6 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     // ToDo? Set model(s) based on extention to model map?
     // parent objects are compound.
     // $this->models = 'islandora:compoundCModel';
-    dd($this->compoundObjFilePath, 'Parent path from addRelationshipsForParent');
   }
 
   /**
@@ -274,13 +263,13 @@ EOQ;
     return FALSE;
   }
 
-  private function loadObjDatastream($path_to_obj_file) {
+  private function loadObjDatastream() {
     $obj = $this->constructDatastream('OBJ', 'M');
     $obj->label = 'OBJ Datastream';
     // Must infer mimetype from file.
     $mime_detector = new MimeDetect();
-    $obj->mimetype = $mime_detector->getMimetype($path_to_obj_file);
-    $obj->setContentFromFile($path_to_obj_file, FALSE);
+    $obj->mimetype = $mime_detector->getMimetype($this->compoundObjFilePath);
+    $obj->setContentFromFile($this->compoundObjFilePath, FALSE);
     $this->ingestDatastream($obj);
   }
 

--- a/includes/object.inc
+++ b/includes/object.inc
@@ -33,11 +33,11 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     $dir_name = $pathinfo['dirname'];
     $file_name = $pathinfo['filename'];
     if ($file_name == 'OBJ') {
-      $this->loadObjDatastream();
+      $this->ingestObjDatastream();
     }
 
     module_load_include('inc', 'islandora_compound_batch', 'includes/utilities');
-    $cb_utilities = new Utilies();
+    $cb_utilities = new Utilities();
 
     // MODS, then from it DC, datastreams.
     if ($mods = $this->getMods()) {
@@ -110,6 +110,7 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
         $file_extension = pathinfo($obj_file_list[0], PATHINFO_EXTENSION);
         $parent_content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
         $this->models = $parent_content_model;
+        $this->ingestObjDatastream($obj_file_list[0]);
       }
       else {
         $this->models = 'islandora:compoundCModel';
@@ -164,18 +165,9 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
   }
 
   /**
-   * Implements addRelationships.
+   * Implements abstract class defined in the main Batch class.
    */
   public function addRelationships() {
-  }
-
-  /**
-   * Add basic relationships for parent object.
-   */
-  public function addRelationshipsForParent() {
-    // ToDo? Set model(s) based on extention to model map?
-    // parent objects are compound.
-    // $this->models = 'islandora:compoundCModel';
   }
 
   /**
@@ -195,7 +187,7 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
   }
 
   /**
-   * Get a list of resources.
+   * Implements abstract class defined in the main Batch class.
    */
   public function getResources() {
     return array();
@@ -235,7 +227,7 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     }
     else if(file_exists($marcxml_file_path)) {
       // There is no MODS but there is MARCXML.
-      $cb_utilities = new Utilies();
+      $cb_utilities = new Utilities();
       $path_to_marc_to_mods_xsl = drupal_get_path('module', 'islandora_batch') . '/transforms/MARC21slim2MODS3-4.xsl';
       $marc_to_mods_xsl = file_get_contents($path_to_marc_to_mods_xsl);
       // Compound batch utilities class.
@@ -263,13 +255,29 @@ EOQ;
     return FALSE;
   }
 
-  private function loadObjDatastream() {
+  /**
+   * Creates an OBJ datastream.
+   *
+   * @param string $path_to_obj
+   *   If present, the absolut path to the file to use as
+   *   the OBJ datastream content.
+   **/
+  private function ingestObjDatastream($path_to_obj = NULL) {
+    if ($this['OBJ']) {
+      return;
+    }
     $obj = $this->constructDatastream('OBJ', 'M');
     $obj->label = 'OBJ Datastream';
     // Must infer mimetype from file.
     $mime_detector = new MimeDetect();
-    $obj->mimetype = $mime_detector->getMimetype($this->compoundObjFilePath);
-    $obj->setContentFromFile($this->compoundObjFilePath, FALSE);
+    if (is_null($path_to_obj)) {
+      $obj->mimetype = $mime_detector->getMimetype($this->compoundObjFilePath);
+      $obj->setContentFromFile($this->compoundObjFilePath, FALSE);
+    }
+    else {
+      $obj->mimetype = $mime_detector->getMimetype($path_to_obj);
+      $obj->setContentFromFile($path_to_obj, FALSE);
+    }
     $this->ingestDatastream($obj);
   }
 

--- a/includes/object.inc
+++ b/includes/object.inc
@@ -32,7 +32,9 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
     $pathinfo = pathinfo($this->compoundObjFilePath);
     $dir_name = $pathinfo['dirname'];
     $file_name = $pathinfo['filename'];
-    if ($file_name != 'MODS') {
+    if ($file_name != 'MODS' || $file_name != 'OBJ') {
+      $this->loadObjDatastream($this->compoundObjFilePath);
+/*
       $obj = $this->constructDatastream('OBJ', 'M');
       $obj->label = 'OBJ Datastream';
       // Must infer mimetype from file.
@@ -40,6 +42,7 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
       $obj->mimetype = $mime_detector->getMimetype($this->compoundObjFilePath);
       $obj->setContentFromFile($this->compoundObjFilePath, FALSE);
       $this->ingestDatastream($obj);
+*/
     }
 
     module_load_include('inc', 'islandora_compound_batch', 'includes/utilities');
@@ -110,7 +113,17 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
       }
     }
     else {
-      $this->models = 'islandora:compoundCModel';
+      $parent_obj_pattern = $dir_name . DIRECTORY_SEPARATOR . 'OBJ.*';
+      $obj_file_list = glob($parent_obj_pattern);
+      dd($obj_file_list, 'OBJ file list');
+      if (count($obj_file_list) === 1) {
+        $file_extension = pathinfo($obj_file_list[0], PATHINFO_EXTENSION);
+        $parent_content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
+        $this->models = $parent_content_model;
+      }
+      else {
+        $this->models = 'islandora:compoundCModel';
+      }
       $this->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $this->preprocessorParameters['parent']);
     }
 
@@ -172,7 +185,8 @@ class IslandoraCompoundBatchObject extends IslandoraBatchObject {
   public function addRelationshipsForParent() {
     // ToDo? Set model(s) based on extention to model map?
     // parent objects are compound.
-    $this->models = 'islandora:compoundCModel';
+    // $this->models = 'islandora:compoundCModel';
+    dd($this->compoundObjFilePath, 'Parent path from addRelationshipsForParent');
   }
 
   /**
@@ -260,4 +274,15 @@ EOQ;
     return FALSE;
   }
 
+  private function loadObjDatastream($path_to_obj_file) {
+    $obj = $this->constructDatastream('OBJ', 'M');
+    $obj->label = 'OBJ Datastream';
+    // Must infer mimetype from file.
+    $mime_detector = new MimeDetect();
+    $obj->mimetype = $mime_detector->getMimetype($path_to_obj_file);
+    $obj->setContentFromFile($path_to_obj_file, FALSE);
+    $this->ingestDatastream($obj);
+  }
+
 }
+

--- a/includes/preprocessor.inc
+++ b/includes/preprocessor.inc
@@ -48,17 +48,29 @@ class IslandoraCompoundBatchPreprocessor extends IslandoraBatchPreprocessor {
         $added[] = $batch_object;
       }
       if ($file_name_with_extension == 'structure.xml') {
-
         // The structure file will be in the root directory of the compound
         // object.  We need to create a parent wrapper object to associate
-        // the OBJ child objects too.  Along with the structure file in the
+        // the child objects too. Along with the structure file in the
         // root directory of the compound object there should be a MODS file
         // (or other metadata file) giving information about the object.
-        // Associate this with the batch object.
+        // Associate this with the batch object. There may also be an OBJ file
+        // that belongs to non-islandora:compoundCModel parent objects.
         $parent_mods_file_path = dirname($file_path) . DIRECTORY_SEPARATOR . 'MODS.xml';
         $batch_object = new IslandoraCompoundBatchObject($this->connection, $parent_mods_file_path, $this->parameters);
-        // Parent wrapper object must be compound.
-        $batch_object->models = 'islandora:compoundCmodel';
+
+        $parent_obj_pattern = dirname($file_path) . DIRECTORY_SEPARATOR . 'OBJ.*';
+        $obj_file_list = glob($parent_obj_pattern);
+        if (count($obj_file_list) === 1) {
+          $file_extension = pathinfo($obj_file_list[0], PATHINFO_EXTENSION);
+          $parent_content_model = $cb_utilities->getContentModelFromFileExt($file_extension);
+          // Parent wrapper object is determined by extension of any OBJ file present.
+          $batch_object->models = $parent_content_model;
+        }
+        else {
+          // Parent wrapper object is compound.
+          $batch_object->models = 'islandora:compoundCmodel';
+        }
+
         // Ad the instance to the Islandora batch queue.
         // Returns PID for parent object.
         $compound_object_pid = $this->addToDatabase($batch_object);

--- a/includes/preprocessor.inc
+++ b/includes/preprocessor.inc
@@ -16,7 +16,6 @@ class IslandoraCompoundBatchPreprocessor extends IslandoraBatchPreprocessor {
    * Function to get the OBJ XML files from the input directory.
    */
   public function preprocess() {
-
     if (strtolower($this->parameters['icbp_verbose']) == 'true') {
       $this->icbpVerbose = TRUE;
     }
@@ -33,15 +32,35 @@ class IslandoraCompoundBatchPreprocessor extends IslandoraBatchPreprocessor {
     $iterator = new RecursiveIteratorIterator($dir);
 
     // Compound batch utilities class.
-    $cb_utilities = new Utilies();
-
+    $cb_utilities = new Utilities();
     $files = array();
     foreach ($iterator as $fileinfo) {
       $file_path = $fileinfo->getPathname();
+      $file_dir = pathinfo($file_path, PATHINFO_DIRNAME);
+      $file_grandparent_dir = pathinfo($file_dir, PATHINFO_DIRNAME);
       $file_extension = pathinfo($file_path, PATHINFO_EXTENSION);
+      $file_name = pathinfo($file_path, PATHINFO_FILENAME);
       $file_name_with_extension = basename($file_path);
       $is_obj_file = $cb_utilities->extInContentModelMap($file_extension);
       if ($fileinfo->isFile() && $is_obj_file) {
+        // A parent object that does not have the content model
+        // 'islandora:compoundCmodel' may have a file named 'OBJ' in its
+        // input directory. This OBJ file should be added to the parent
+        // object as a datastream and not ingested as a separate object. To
+        // prevent this, we compare the parent object's parent directory to the
+        // batch job's input directory, since our input is organized such that
+        // each parent object is in a child of the input directory (i.e., one
+        // level below it). Check here and skip ingesting any objects whose
+        // parent directoy is a direct child of the batch's input directory.
+        if ($is_obj_file) {
+          // Compare its grandparent directory to the batch's input directory.
+          if ($file_grandparent_dir == rtrim($input_path, '/')) {
+            // If they are the same, do not add this object to the queue since
+            // the OBJ file is a datastream of the parent object, not its
+            // own object.
+            continue;
+          }
+        }
         $batch_object = new IslandoraCompoundBatchObject($this->connection, $file_path, $this->parameters);
         // Add the instances to the Islandora batch queue.
         $this->addToDatabase($batch_object);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -6,9 +6,9 @@
  */
 
 /**
- * Utilies class .
+ * Utilities class .
  */
-class Utilies {
+class Utilities{
 
   /**
    * Extension to Islandora content model map


### PR DESCRIPTION
This PR adds new functionality described in #26 plus addresses some cleanup described in #33 and #34.
WRT #26, I have only implemented the "presence of an OBJ file in the parent's directory" option and not any Drush options. I have also updated the README file to describe this new option. I will open PRs for the other options later if we decide we want them.

To test this PR:

1. Make sure that the Compound Solution Pack's "Only allow compound objects to have child objects associated with them" option is unchecked.
1. Unzip the attached .zip file and ingest its contents: `drush -v --user=admin islandora_compound_batch_preprocess --target=/vagrant/issue26test --namespace=islandora --parent=some:collection`, then `sudo drush -v --user=admin islandora_batch_ingest`. This should create two compound objects, "First compound object" (3 children) and "Second compound object" (4 children). The changes in this PR should not have any effect during this test ingest.
1. Delete both of these objects from your collection.
1. Copy the attached PDF file into the 'compound1' root directory, so it is a sibling of 'compound1/MODS.xml'.
1. Re-ingest the objects, as above. The changes in this PR will have had the following effect: "First compound object" will now have the PDF Content Model, and will have the file you copied as its OBJ datastream. However,  "First compound object" will also have three children, as it did during the first ingest.

[issue26test.zip](https://github.com/MarcusBarnes/islandora_compound_batch/files/2198158/issue26test.zip)
[OBJ.pdf](https://github.com/MarcusBarnes/islandora_compound_batch/files/2198162/OBJ.pdf)
